### PR TITLE
Updated homepage URL in manifest

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/manifest.json
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/manifest.json
@@ -2,7 +2,7 @@
     "name": "Puzzle Tokens",
     "description": "Apply design tokens to Sketch styles",
     "author": "Maxim Bazarov",
-    "homepage": "",
+    "homepage": "https://github.com/ingrammicro/puzzle-tokens",
     "identifier": "com.cloudblue.sketch.ds",
     "appcast": "https://raw.githubusercontent.com/ingrammicro/puzzle-tokens/master/appcast.xml",
     "compatibleVersion": 3,


### PR DESCRIPTION
The empty `homepage` attribute in manifest.json throws an error when viewing the plugin in Sketch Runner.