### PR TITLE
Update `border-style` to take `border-width` into consideration.

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
@@ -825,9 +825,9 @@ class DSApp {
         if (null != borderStyle) {
             if (undefined == sStyle.borderOptions) sStyle.borderOptions = {}
             if ("dashed" == borderStyle) {
-                sStyle.borderOptions.dashPattern = [4, 4]
+                sStyle.borderOptions.dashPattern = [3 * borderWidth, 3 * borderWidth]
             } else if ("dotted" == borderStyle) {
-                sStyle.borderOptions.dashPattern = [1, 1]
+                sStyle.borderOptions.dashPattern = [1 * borderWidth, 1 * borderWidth]
             }
         }
 


### PR DESCRIPTION
Related to discussion on #4, this removes the hard-coding of border-styles and makes it relative to the width.