### PR TITLE
If box-shadow:none, clear any existing shadows from the layer style.

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
@@ -1065,6 +1065,7 @@ class DSApp {
         if (shadowCSS != null && shadowCSS != "" && shadowCSS != "none") {
             shadows = Utils.splitCSSShadows(shadowCSS)
         } else {
+            if (shadowCSS == 'none') sStyle.shadows = [] //clear any existing shadows
         }
 
         if (!shadows || !shadows.length) {


### PR DESCRIPTION
Another suggestion for you. When box-shadow:none, clear any existing shadow styles.

(It possibly makes sense to do the same for border-style:none, too? But for now, here's the tweak for box-shadow:none.)

Thanks again, really enjoying your plugin!