### PR TITLE
`-pt-smartlayout: none` clears any smart layout on a symbol master or group

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
@@ -1340,7 +1340,7 @@ class DSApp {
         var smartLayout = token[PT_SMARTLAYOUT]
         if (smartLayout != null) {
             const value = smartLayoutMap[smartLayout]
-            if (null == value) {
+            if (null == value && "none" != smartLayout.toLowerCase() ) {
                 return this.logError("Can not understand rule " + PT_SMARTLAYOUT + ": " + smartLayout)
             }
             l.smartLayout = value

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following CSS styles are supporting.
 // Group & SymbolMaster Properties
 .Group{
     -pt-smartlayout:         LeftToRight; // LeftToRight OR HorizontallyCenter OR RightToLeft OR TopToBottom 
-                                          // OR VerticallyCenter OR BottomToTop
+                                          // OR VerticallyCenter OR BottomToTop OR None
 }
 
 #Image{


### PR DESCRIPTION
This pull request adds the ability to set smart layout to none. Thanks for all you do!