### PR TITLE
Margin enhancements and auto-resizing

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/constants.js
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/constants.js
@@ -85,6 +85,10 @@ const PT_BORDER_UPDATE = "-pt-border-update"
 const PT_FILL_UPDATE = "-pt-fill-update"
 const PT_SKIP_MISSED = "-pt-skip-missed"
 const PT_SHADOW_UPDATE = "-pt-shadow-update"
+const PT_MARGIN_RELATIVE_TO = "-pt-margin-relative-to"
+const PT_MARGIN_RESIZE = "-pt-margin-resize"
+const PT_FIT_CONTENT = "-pt-fit-content"
+const PT_RESIZE_INSTANCES = "-pt-resize-instances"
 
 const THIS_NAME = "_This"
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,36 @@ The following CSS styles are supporting.
     // through style assigned to it. You can also
     // apply it to the layers or symbols directly.
 
-    margin-top:             10px;
-    margin-left:            10px;
-    margin-right:           10px;
-    margin-bottom:          10px;
     width:                  100px;
-    height:                 100px;        
+    height:                 100px;
+
+    margin-top:             10px;
+    margin-left:            20px;
+    margin-right:           20px;
+    margin-bottom:          10px;
+    
+    // By default, margin is set relative to the layer's containing artboard or page.
+    // (Specifically, the layer is moved so that it is positioned inside the artboard/
+    // page at the specified margin. In the example above, the top-left corner of the
+    // layer is set to x:10 and y:20 of the containing artboard.)
+    //
+    // If you prefer to set the margin  relative to another layer (for example, to set 
+    // the text layer of a button within the boundaries of the button's background
+    // layer style), use the "-pt-margin-relative-to" property shown below.
+    
+    -pt-margin-relative-to: "layer name"; // set margin values relative to the specified
+                                          // layer. The specified layer must be a sibling
+                                          // (at the same level in a group, artboard, or
+                                          // symbol) of the layer to which you are
+                                          // applying the margin styles. If not specified,
+                                          // margin will be set relative to the artboard
+                                          // or page
+    -pt-margin-resize:      true;         // if true, resize the "margin-relative-to"
+                                          // layer to "fit" the size of the current layer,
+                                          // plus the specified margin. This will make
+                                          // the "margin-relative-to" layer surround
+                                          // the current layer at exactly the requested
+                                          // margin.
 }
 
 // Group & SymbolMaster Properties
@@ -120,6 +144,19 @@ The following CSS styles are supporting.
     -pt-smartlayout:         LeftToRight; // LeftToRight OR HorizontallyCenter OR RightToLeft OR TopToBottom 
                                           // OR VerticallyCenter OR BottomToTop OR None
 }
+
+// SymbolMaster and Artboard Properties
+    -pt-fit-content:        true;        // Resize the symbol or artboard to fit content
+}
+
+// SymbolMaster Properties
+    -pt-resize-instances:   true;        // Resize all instances of a symbol; the same as
+                                         // clicking Sketch's "Shrink instance to fit
+                                         // content" button in the Overrides section of
+                                         // the instance. (This reapplies SmartLayout,
+                                         // useful when you change the size of a symbol.)
+}
+
 
 #Image{
     // Required Properties


### PR DESCRIPTION
This pull request adds four new properties, which are specifically intended to be helpful for managing the spacing and size within buttons, for example.

### Margin enhancements

`-pt-margin-relative-to: "layer name";`
This sets margin values relative to the specified layer. The specified layer must be a sibling at the same level in a group, artboard, or symbol) of the layer to which you are applying the margin styles. If not specified, margin will be set relative to the artboard or page (which is the current behavior).

`-pt-margin-resize: true;`
If true, resize the "margin-relative-to" layer to "fit" the size of the current layer, plus the specified margin. This will make the "margin-relative-to" layer surround the current layer at exactly the requested margin. (Very helpful for effectively setting the padding of buttons and sizing the surrounding background layer to fit.)

### Artboard/symbol resizing

`-pt-fit-content: true;`
Applies only to artboards and symbol masters: if true, resize the artboard/symbol to fit its content.

`-pt-resize-instances: true;`
Applies only to symbol masters. If true, resize all instances of a symbol; the same as clicking Sketch's "Shrink instance to fit content" button in the Overrides section of the instance. (This reapplies SmartLayout, useful when you change the size of a symbol.)

----

- Updated README to document these properties.
- Change in behavior. Old margin-handling behavior set position based on margin-bottom and margin-right in preference to margin-top and margin-left. New behavior flips that to prefer margin-top and margin-left.