### PR TITLE
Change declaration of updateFill from const to var

### DIFF
--- a/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
+++ b/PuzzleTokens.sketchplugin/Contents/Sketch/classes/DSApp.js
@@ -1290,7 +1290,7 @@ class DSApp {
         const token = rule.props
         // SET COLOR        
         let backColor = token['background-color']
-        const updateFill = token[PT_FILL_UPDATE] == 'true'
+        var updateFill = token[PT_FILL_UPDATE] == 'true'
         if (backColor != null) {
             let fill = {}
             if (updateFill) {


### PR DESCRIPTION
Line 1301 assigns a new value to updateFill, which threw an error since updateFill
is declared as a constant: "TypeError: Attempted to assign to readonly property."
Changing to var fixes it.